### PR TITLE
Rechtschreibfehler

### DIFF
--- a/Herbstlied_Liedblatt.tex
+++ b/Herbstlied_Liedblatt.tex
@@ -74,7 +74,7 @@ Zipfel\chort{D}{mützenkinder} \chort{B}{steh’n} im \chort{F}{Pfützen}\chort{
 Streuobst\chort{C}{äpfel} fall’n ins \chort{A}{knietief} \chort{A$^7$}{hohe} \chort{A}{Gras}
 
 \textbf{3.}
-\chort{d}{Zärlich} \chort{a}{klingt} ein \chort{C}{kleines} \chort{F}{Lied}
+\chort{d}{Zärtlich} \chort{a}{klingt} ein \chort{C}{kleines} \chort{F}{Lied}
 \chort{d}{spricht} da\chort{a}{von} \chort{G}{wie} Glück ge\chort{E}{schieht.}
 \chort{A}{kleine} \chort{g}{Töne,} \chort{F}{leises} \chort{E}{Wort,}
 \chort{A}{finden} \chort{g}{Ohren} an \chort{F}{ihrem}\chort{A}{Ort.}\\[0.5em]


### PR DESCRIPTION
zär-t-lich